### PR TITLE
Combobox

### DIFF
--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { ChevronDown } from "lucide-react";
+import { Database } from "@/types/db";
+import { Control } from "react-hook-form";
+
+type Account = Database["public"]["Tables"]["accounts"]["Row"];
+
+interface AccountComboBoxProps {
+  accounts: Account[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export const AccountComboBox = ({
+  accounts,
+  value,
+  onChange,
+  placeholder = "Enter Account"
+}: AccountComboBoxProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Update input value when selected value changes
+  useEffect(() => {
+    if (value) {
+      const selectedAccount = accounts.find(acc => acc.account_number === value);
+      if (selectedAccount) {
+        setInputValue(value);
+      }
+    } else {
+      setInputValue("");
+    }
+  }, [value, accounts]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current && 
+        !dropdownRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    // Only update the actual value when a full account number is entered (12 digits)
+    if (e.target.value.length === 12 && /^\d+$/.test(e.target.value)) {
+      onChange(e.target.value);
+    }
+  };
+
+  const handleSelect = (accountNumber: string) => {
+    onChange(accountNumber);
+    setInputValue(accountNumber);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative w-full">
+      <div className="relative">
+        <Input
+          ref={inputRef}
+          value={inputValue}
+          onChange={handleInputChange}
+          placeholder={placeholder}
+          className="pr-10 rounded-md border border-input"
+          onClick={() => setIsOpen(true)}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute right-0 top-0 h-full"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </div>
+      
+      {isOpen && (
+        <div 
+          ref={dropdownRef}
+          className="absolute z-50 w-full mt-1 bg-popover rounded-md border shadow-md"
+        >
+          <div className="max-h-60 overflow-auto p-1">
+            {accounts.map((account) => (
+              <div
+                key={account.account_number}
+                className="relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                onClick={() => handleSelect(account.account_number)}
+              >
+                {account.name} - {account.account_number}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Helper component to use with react-hook-form
+export const AccountFormField = ({ 
+  control, 
+  name, 
+  accounts, 
+  label 
+}: {
+  control: Control<Record<string, unknown>>;
+  name: string;
+  accounts: Account[];
+  label: string;
+}) => (
+  <FormField
+    control={control}
+    name={name}
+    render={({ field }) => (
+      <FormItem>
+        <FormLabel>{label}</FormLabel>
+        <FormControl>
+          <AccountComboBox
+            accounts={accounts}
+            value={field.value as string}
+            onChange={field.onChange}
+            placeholder="Enter Account"
+          />
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+    )}
+  />
+);

--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -81,7 +81,6 @@ export const AccountComboBox = ({
     }
   };
 
-  // Add this parsing function to strip formatting for validation
   const parseAccountNumber = (formattedValue: string): string => {
     return formattedValue.replace(/\D/g, '');
   };
@@ -103,9 +102,12 @@ export const AccountComboBox = ({
     // Update input with formatted value
     setInputValue(formattedValue);
     
-    // Only update the form value when a full account number is entered (12 digits)
+    // Only update the form value when EXACTLY 12 digits are entered
     if (digits.length === 12) {
       onChange(digits); // Store the raw digits in the form state
+    } else {
+      // If it's not 12 digits, set an empty value so the form validation fails
+      onChange("");
     }
     
     // Calculate new cursor position after formatting

--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -66,10 +66,17 @@ export const AccountComboBox = ({
   }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-    // Only update the actual value when a full account number is entered (12 digits)
-    if (e.target.value.length === 12 && /^\d+$/.test(e.target.value)) {
-      onChange(e.target.value);
+    // Only allow digits in the input
+    const newValue = e.target.value.replace(/[^\d]/g, '');
+    
+    // Update input only if it's empty or contains only digits
+    if (newValue === '' || /^\d+$/.test(newValue)) {
+      setInputValue(newValue);
+      
+      // Only update the form value when a full account number is entered (12 digits)
+      if (newValue.length === 12) {
+        onChange(newValue);
+      }
     }
   };
 

--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -171,7 +171,7 @@ export const AccountComboBox = ({
                 className="relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
                 onClick={() => handleSelect(account.account_number)}
               >
-                {account.name} - {formatAccountNumber(account.account_number)}
+                {account.name} {formatAccountNumber(account.account_number)}
               </div>
             ))}
           </div>

--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -89,56 +89,41 @@ export const AccountComboBox = ({
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // Get the current cursor position
     const cursorPosition = e.target.selectionStart || 0;
-    
-    // Filter out non-digit characters from the input
     const rawInput = e.target.value.replace(/[^\d-]/g, '');
     const digits = parseAccountNumber(rawInput);
-    
-    // Enforce maximum 12 digits
-    // If trying to add more than 12 digits, prevent the change
+  
+    // Enforce max 12 digits
     if (digits.length > 12) {
-      // Keep existing value instead of accepting the new input
       return;
     }
-    
-    // Format the value with dashes
+  
     const formattedValue = formatAccountNumber(digits);
-    
-    // Update input with formatted value
     setInputValue(formattedValue);
-    
-    // Only update the form value when EXACTLY 12 digits are entered
-    if (digits.length === 12) {
-      onChange(digits); // Store the raw digits in the form state
-    } else {
-      // If not 12 digits, set empty string so validation will fail
-      onChange("");
-    }
-    
-    // Calculate new cursor position after formatting
+  
+    onChange(digits);
+  
     setTimeout(() => {
-      // Adjust cursor position based on how many dashes were added
       let newPosition = cursorPosition;
-      
-      // If we just typed the 4th or 8th digit, move cursor past the dash
+  
       if (digits.length === 4 && cursorPosition === 4) {
         newPosition = 5;
       } else if (digits.length === 8 && cursorPosition === 9) {
         newPosition = 10;
       }
-      
-      // If we deleted a character and the cursor is at a dash, move cursor back
-      if (e.target.value.length < inputValue.length && 
-          (cursorPosition === 5 || cursorPosition === 10)) {
+  
+      if (
+        e.target.value.length < inputValue.length &&
+        (cursorPosition === 5 || cursorPosition === 10)
+      ) {
         newPosition = cursorPosition - 1;
       }
-      
-      // Set the new cursor position
+  
+      newPosition = Math.min(newPosition, formattedValue.length);
       e.target.setSelectionRange(newPosition, newPosition);
     }, 0);
   };
+  
 
   const handleSelect = (accountNumber: string) => {
     onChange(accountNumber);

--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -66,19 +66,22 @@ export const AccountComboBox = ({
     };
   }, []);
 
-  // Add this formatting function
   const formatAccountNumber = (value: string): string => {
     // Remove any non-digit characters
     const digits = value.replace(/\D/g, '');
     
-    // Apply formatting pattern (1111-1111-1111)
-    if (digits.length <= 4) {
-      return digits;
-    } else if (digits.length <= 8) {
-      return `${digits.slice(0, 4)}-${digits.slice(4)}`;
-    } else {
-      return `${digits.slice(0, 4)}-${digits.slice(4, 8)}-${digits.slice(8, 12)}`;
+    // Start building the formatted result
+    let formatted = '';
+    
+    // Apply formatting pattern, with dashes after every 4 digits
+    for (let i = 0; i < digits.length; i++) {
+      if (i > 0 && i % 4 === 0) {
+        formatted += '-';
+      }
+      formatted += digits[i];
     }
+    
+    return formatted;
   };
 
   const parseAccountNumber = (formattedValue: string): string => {
@@ -89,15 +92,19 @@ export const AccountComboBox = ({
     // Get the current cursor position
     const cursorPosition = e.target.selectionStart || 0;
     
-    // Only allow digits in the input
-    const rawValue = e.target.value.replace(/[^\d-]/g, '');
-    const digits = parseAccountNumber(rawValue);
+    // Filter out non-digit characters from the input
+    const rawInput = e.target.value.replace(/[^\d-]/g, '');
+    const digits = parseAccountNumber(rawInput);
     
-    // Limit to 12 digits maximum
-    const limitedDigits = digits.slice(0, 12);
+    // Enforce maximum 12 digits
+    // If trying to add more than 12 digits, prevent the change
+    if (digits.length > 12) {
+      // Keep existing value instead of accepting the new input
+      return;
+    }
     
-    // Format the value
-    const formattedValue = formatAccountNumber(limitedDigits);
+    // Format the value with dashes
+    const formattedValue = formatAccountNumber(digits);
     
     // Update input with formatted value
     setInputValue(formattedValue);
@@ -106,7 +113,7 @@ export const AccountComboBox = ({
     if (digits.length === 12) {
       onChange(digits); // Store the raw digits in the form state
     } else {
-      // If it's not 12 digits, set an empty value so the form validation fails
+      // If not 12 digits, set empty string so validation will fail
       onChange("");
     }
     

--- a/bank/src/components/transfer-form.tsx
+++ b/bank/src/components/transfer-form.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { ArrowRightLeft } from "lucide-react";
+import { AccountComboBox } from "@/components/account-combobox";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -142,34 +143,22 @@ export default function TransferForm({ accounts }: ITransferFormProps) {
                 />
 
                 <FormField
-                  control={form.control}
-                  name="toAccount"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>To Account</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select account" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {accounts.map((account) => (
-                            <SelectItem
-                              key={account.id}
-                              value={account.account_number}
-                            >
-                              {account.name} - ${account.balance}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                control={form.control}
+                name="toAccount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>To Account</FormLabel>
+                    <FormControl>
+                      <AccountComboBox
+                        accounts={accounts}
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Enter Account"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
                 />
               </div>
 

--- a/bank/src/services/banking/account.ts
+++ b/bank/src/services/banking/account.ts
@@ -334,6 +334,11 @@ export async function transfer(
   amount: number,
   create_transaction: boolean = true,
 ) {
+  // Validate account numbers are exactly 12 digits
+  if (!/^\d{12}$/.test(src_account_number) || !/^\d{12}$/.test(dest_account_number)) {
+    throw new ClientError("Account numbers must be exactly 12 digits", 400);
+  }
+
   await getAuthUser();
   const src_account = await getUserAccount(src_account_number);
   
@@ -342,8 +347,7 @@ export async function transfer(
   try {
     dest_account = await getUserAccount(dest_account_number);
   } catch (error) {
-    // If destination account doesn't exist, just deduct the money
-    // without depositing to any account (simulate external transfer)
+    // If destination account doesn't exist, just proceed with withdrawal
     console.log(`Destination account ${dest_account_number} not found. Processing as external transfer.`);
   }
 

--- a/bank/src/services/banking/account.ts
+++ b/bank/src/services/banking/account.ts
@@ -326,8 +326,6 @@ export async function withdraw(
   );
 }
 
-// In your services/banking/account.ts file, modify the transfer function:
-
 export async function transfer(
   src_account_number: string,
   dest_account_number: string,

--- a/bank/src/utils/zod/form.ts
+++ b/bank/src/utils/zod/form.ts
@@ -47,32 +47,27 @@ export const CreateAccountFormSchema = z.object({
   account_type: z.enum(["Checking", "Savings"]),
 });
 
-export const TransferFormSchema = z
-  .object({
-    fromAccount: z.string({
-      required_error: "Please select an account to transfer from",
+export const TransferFormSchema = z.object({
+  fromAccount: z.string({
+    required_error: "Please select an account to transfer from",
+  }),
+  toAccount: z.string({
+    required_error: "Please select an account to transfer to",
+  }),
+  amount: z.number().refine(
+    (val) => {
+      return !isNaN(val) && val > 0;
+    },
+    {
+      message: "Amount must be greater than 0",
+    },
+  ),
+  confirmTransfer: z.literal(true, {
+    errorMap: () => ({
+      message: "You must confirm the transfer details",
     }),
-    toAccount: z.string({
-      required_error: "Please select an account to transfer to",
-    }),
-    amount: z.number().refine(
-      (val) => {
-        return !isNaN(val) && val > 0;
-      },
-      {
-        message: "Amount must be greater than 0",
-      },
-    ),
-    confirmTransfer: z.literal(true, {
-      errorMap: () => ({
-        message: "You must confirm the transfer details",
-      }),
-    }),
-  })
-  .refine((data) => data.fromAccount !== data.toAccount, {
-    message: "From and To accounts must be different",
-    path: ["toAccount"],
-  });
+  }),
+});
 
 export const DepositFormSchema = z.object({
   toAccount: z.string({

--- a/bank/src/utils/zod/form.ts
+++ b/bank/src/utils/zod/form.ts
@@ -50,9 +50,13 @@ export const CreateAccountFormSchema = z.object({
 export const TransferFormSchema = z.object({
   fromAccount: z.string({
     required_error: "Please select an account to transfer from",
+  }).refine(value => value.length === 12, {
+    message: "Account number must be exactly 12 digits",
   }),
   toAccount: z.string({
     required_error: "Please select an account to transfer to",
+  }).refine(value => value.length === 12, {
+    message: "Account number must be exactly 12 digits",
   }),
   amount: z.number().refine(
     (val) => {


### PR DESCRIPTION
# Pull Request

## Description

- Users are now allowed to transfer to **external bank accounts**.  
- Users can select their own account as the `from` account.  
- The `to` account input only accepts **exactly 12 digits**:
  - If the input is **less than 12 digits**, a prompt will appear:  
    **"Account number must be exactly 12 digits."**
  - If the user tries to enter a **13th digit**, it will be blocked and not appear in the input.

Transfer will only proceed when the account number is exactly 12 digits.  

## Related Issues (if applicable)
<!-- Link to related issues using the format: Fixes #123, Addresses #456 -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Database schema change
- [ ] Refactoring (no functional changes)

## Screenshots (if applicable)
![8f6ccf1293732e0f5a40f3638a028fb](https://github.com/user-attachments/assets/9ee6d4de-f477-43ad-a704-f8ec039b810d)
![43b04efac04c48d16655950591efe60](https://github.com/user-attachments/assets/dce1961f-667e-4dbb-9a0c-35cfdd5a5270)
![c25f798bf7d13d71a7ce543abacd515](https://github.com/user-attachments/assets/3677acfc-744e-42f3-b097-99b27551994b)
