### PR TITLE
Fix combobox

### DIFF
--- a/bank/src/components/account-combobox.tsx
+++ b/bank/src/components/account-combobox.tsx
@@ -40,6 +40,8 @@ export const AccountComboBox = ({
       const selectedAccount = accounts.find(acc => acc.account_number === value);
       if (selectedAccount) {
         // Format the account number when it's set from outside
+        setInputValue(`${selectedAccount.name} ${formatAccountNumber(value)}`);
+      } else {
         setInputValue(formatAccountNumber(value));
       }
     } else {
@@ -125,9 +127,21 @@ export const AccountComboBox = ({
   };
   
 
-  const handleSelect = (accountNumber: string) => {
+  const handleSelect = (accountNumber: string, accountName?: string) => {
     onChange(accountNumber);
-    setInputValue(accountNumber);
+    
+    // Instead of setting just the account number:
+    // setInputValue(accountNumber);
+    
+    // Find the selected account to get its name
+    const selectedAccount = accounts.find(acc => acc.account_number === accountNumber);
+    if (selectedAccount) {
+      // Format the display value to include the account name
+      setInputValue(`${selectedAccount.name} ${formatAccountNumber(accountNumber)}`);
+    } else {
+      setInputValue(formatAccountNumber(accountNumber));
+    }
+    
     setIsOpen(false);
   };
 


### PR DESCRIPTION
# Pull Request

## Description
When you enter 11 digits it won't trigger only when you enter exactly 12 same digits that in the list, then it will filled with `checking 1064-9726-4652`.
When you have `checking 1064-9726-4652` then delete 1 digit like 2 then it will become `1064-9726-465`, then the `checking` will gone, since it is not matched with any listed account anymore.

## Related Issues (if applicable)
<!-- Link to related issues using the format: Fixes #123, Addresses #456 -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Database schema change
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Provide instructions so we can reproduce. -->

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b3ae1498-3ef4-4663-86d7-dd8c1d776824)