### PR TITLE
fix: withdrawing more than acc balance gives unique error

### DIFF
--- a/atm/src/components/transaction-form/index.tsx
+++ b/atm/src/components/transaction-form/index.tsx
@@ -64,6 +64,18 @@ const TransactionForm: React.FC<ITransactionFormProps> = ({
       return false;
     }
 
+    if (transactionType == "Withdraw") {
+      if (!account) {
+        setError("Account information not loaded");
+        return false;
+      }
+      
+      if (numAmount > account.balance) {
+        setError("Insufficient funds");
+        return false;
+      }
+    }
+
     setError("");
     return true;
   };


### PR DESCRIPTION
# Pull Request

## Description
added condition check to see if withdraw amount is more than user's account balance, also checks that account info was pulled before checking balance and displaying the correct error